### PR TITLE
Fix fontnik version from v0.5.0 to v0.5.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   ],
   "dependencies": {
     "@mapbox/glyph-pbf-composite": "0.0.3",
-    "fontnik": "0.5.0"
+    "fontnik": "0.5.3"
   }
 }


### PR DESCRIPTION
Download fontnik package version v0.5.0 fails returning Access Denied (403), because the binary source from v0.5.0 is no longer possible to download.

Url from v.0.5.0 that returns access denied (403):
https://mapbox-node-binary.s3.amazonaws.com/fontnik/v0.5.0/Release/node-v64-linux-x64.tar.gz

But version v0.5.3 works fine, generating all PBFs in the _output folder correctly.
https://mapbox-node-binary.s3.amazonaws.com/fontnik/v0.5.3/Release/node-v64-linux-x64.tar.gz