### PR TITLE
Fixed building with node 12.18.2 (latest LTS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   ],
   "dependencies": {
     "@mapbox/glyph-pbf-composite": "0.0.3",
-    "fontnik": "0.5.3"
+    "fontnik": "0.6.0"
   }
 }


### PR DESCRIPTION
On fontnik 0.5.3 I got a lot of node-gyp building errors such as
```
In file included from ../src/glyphs.hpp:5,
                 from ../src/node_fontnik.cpp:2:
...node_modules/nan/nan.h:1044:37: error: cannot convert «char*» to «v8::Isolate*»
 1044 |         length_ = string->WriteUtf8(str_, static_cast<int>(len), 0, flags);
      |                                     ^~~~
      |                                     |
      |                                     char*
```

Upgrading fontnik to 0.6.0 fixes problem, because it moved to NodeJS N-API