### PR TITLE
upgrade fontnik from 0.6.0 to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   ],
   "dependencies": {
     "@mapbox/glyph-pbf-composite": "0.0.3",
-    "fontnik": "0.6.0"
+    "fontnik": "0.7.2"
   }
 }


### PR DESCRIPTION
This merge request updates the fontnik dependency from version `0.6.0` to `0.7.2`. 

This is necessary because the project is not working on node 18 with the older version of fontnik. 

Please let me know if you have any feedback or questions. Thank you.

```
Cloning into 'fonts'...
remote: Enumerating objects: 8699, done.
remote: Counting objects: 100% (7/7), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 8699 (delta 4), reused 2 (delta 2), pack-reused 8692
Receiving objects: 100% (8699/8699), 149.06 MiB | 1.46 MiB/s, done.
Resolving deltas: 100% (120/120), done.
PWD=/path/to/tmp. Execute npm install
npm WARN deprecated node-pre-gyp@0.14.0: Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future
npm ERR! code 1
npm ERR! path /path/to/tmp/fonts/node_modules/fontnik
npm ERR! command failed
npm ERR! command sh -c node-pre-gyp install --fallback-to-build=true
npm ERR! Failed to execute '/usr/bin/node /usr/share/nodejs/node-gyp/bin/node-gyp.js configure --fallback-to-build=true --module=/path/to/tmp/fonts/node_modules/fontnik/lib/binding/fontnik.node --module_name=fontnik --module_path=/path/to/tmp/fonts/node_modules/fontnik/lib/binding --napi_version=8 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v108' (1)
npm ERR! node-pre-gyp info it worked if it ends with ok
npm ERR! node-pre-gyp info using node-pre-gyp@0.14.0
npm ERR! node-pre-gyp info using node@18.13.0 | linux | x64
npm ERR! node-pre-gyp WARN Using request for node-pre-gyp https download 
npm ERR! node-pre-gyp info check checked for "/path/to/tmp/fonts/node_modules/fontnik/lib/binding/fontnik.node" (not found)
npm ERR! node-pre-gyp http GET https://mapbox-node-binary.s3.amazonaws.com/fontnik/v0.6.0/Release/node-v108-linux-x64.tar.gz
npm ERR! node-pre-gyp http 403 https://mapbox-node-binary.s3.amazonaws.com/fontnik/v0.6.0/Release/node-v108-linux-x64.tar.gz
npm ERR! node-pre-gyp WARN Tried to download(403): https://mapbox-node-binary.s3.amazonaws.com/fontnik/v0.6.0/Release/node-v108-linux-x64.tar.gz 
npm ERR! node-pre-gyp WARN Pre-built binaries not found for fontnik@0.6.0 and node@18.13.0 (node-v108 ABI, glibc) (falling back to source compile with node-gyp) 
npm ERR! node-pre-gyp http 403 status code downloading tarball https://mapbox-node-binary.s3.amazonaws.com/fontnik/v0.6.0/Release/node-v108-linux-x64.tar.gz 
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@9.3.0
npm ERR! gyp info using node@18.13.0 | linux | x64
npm ERR! gyp info ok 
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@9.3.0
npm ERR! gyp info using node@18.13.0 | linux | x64
npm ERR! gyp info find Python using Python version 3.10.12 found at "/opt/conda/bin/python3"
npm ERR! gyp info spawn /opt/conda/bin/python3
npm ERR! gyp info spawn args [
npm ERR! gyp info spawn args   '/usr/share/nodejs/node-gyp/gyp/gyp_main.py',
npm ERR! gyp info spawn args   'binding.gyp',
npm ERR! gyp info spawn args   '-f',
npm ERR! gyp info spawn args   'make',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/path/to/tmp/fonts/node_modules/fontnik/build/config.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/path/to/tmp/fonts/node_modules/fontnik/common.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/usr/share/nodejs/node-gyp/addon.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/usr/include/nodejs/common.gypi',
npm ERR! gyp info spawn args   '-Dlibrary=shared_library',
npm ERR! gyp info spawn args   '-Dvisibility=default',
npm ERR! gyp info spawn args   '-Dnode_root_dir=/usr/include/nodejs',
npm ERR! gyp info spawn args   '-Dnode_gyp_dir=/usr/share/nodejs/node-gyp',
npm ERR! gyp info spawn args   '-Dnode_lib_file=/usr/include/nodejs/<(target_arch)/node.lib',
npm ERR! gyp info spawn args   '-Dmodule_root_dir=/path/to/tmp/fonts/node_modules/fontnik',
npm ERR! gyp info spawn args   '-Dnode_engine=v8',
npm ERR! gyp info spawn args   '--depth=.',
npm ERR! gyp info spawn args   '--no-parallel',
npm ERR! gyp info spawn args   '--generator-output',
npm ERR! gyp info spawn args   'build',
npm ERR! gyp info spawn args   '-Goutput_dir=.'
npm ERR! gyp info spawn args ]
npm ERR! Traceback (most recent call last):
npm ERR!   File "/usr/share/nodejs/node-gyp/gyp/gyp_main.py", line 33, in <module>
npm ERR!     sys.exit(load_entry_point('gyp==0.1', 'console_scripts', 'gyp')())
npm ERR!   File "/usr/share/nodejs/node-gyp/gyp/gyp_main.py", line 22, in importlib_load_entry_point
npm ERR!     for entry_point in distribution(dist_name).entry_points
npm ERR!   File "/opt/conda/lib/python3.10/importlib/metadata/__init__.py", line 969, in distribution
npm ERR!     return Distribution.from_name(distribution_name)
npm ERR!   File "/opt/conda/lib/python3.10/importlib/metadata/__init__.py", line 548, in from_name
npm ERR!     raise PackageNotFoundError(name)
npm ERR! importlib.metadata.PackageNotFoundError: No package metadata was found for gyp
npm ERR! gyp ERR! configure error 
npm ERR! gyp ERR! stack Error: `gyp` failed with exit code: 1
npm ERR! gyp ERR! stack     at ChildProcess.onCpExit (/usr/share/nodejs/node-gyp/lib/configure.js:329:16)
npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:513:28)
npm ERR! gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
npm ERR! gyp ERR! System Linux 5.15.0-76-generic
npm ERR! gyp ERR! command "/usr/bin/node" "/usr/share/nodejs/node-gyp/bin/node-gyp.js" "configure" "--fallback-to-build=true" "--module=/path/to/tmp/fonts/node_modules/fontnik/lib/binding/fontnik.node" "--module_name=fontnik" "--module_path=/path/to/tmp/fonts/node_modules/fontnik/lib/binding" "--napi_version=8" "--node_abi_napi=napi" "--napi_build_version=0" "--node_napi_label=node-v108"
npm ERR! gyp ERR! cwd /path/to/tmp/fonts/node_modules/fontnik
npm ERR! gyp ERR! node -v v18.13.0
npm ERR! gyp ERR! node-gyp -v v9.3.0
npm ERR! gyp ERR! not ok 
npm ERR! node-pre-gyp ERR! build error 
npm ERR! node-pre-gyp ERR! stack Error: Failed to execute '/usr/bin/node /usr/share/nodejs/node-gyp/bin/node-gyp.js configure --fallback-to-build=true --module=/path/to/tmp/fonts/node_modules/fontnik/lib/binding/fontnik.node --module_name=fontnik --module_path=/path/to/tmp/fonts/node_modules/fontnik/lib/binding --napi_version=8 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v108' (1)
npm ERR! node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/path/to/tmp/fonts/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
npm ERR! node-pre-gyp ERR! stack     at ChildProcess.emit (node:events:513:28)
npm ERR! node-pre-gyp ERR! stack     at maybeClose (node:internal/child_process:1091:16)
npm ERR! node-pre-gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:302:5)
npm ERR! node-pre-gyp ERR! System Linux 5.15.0-76-generic
npm ERR! node-pre-gyp ERR! command "/usr/bin/node" "/path/to/tmp/fonts/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build=true"
npm ERR! node-pre-gyp ERR! cwd /path/to/tmp/fonts/node_modules/fontnik
npm ERR! node-pre-gyp ERR! node -v v18.13.0
npm ERR! node-pre-gyp ERR! node-pre-gyp -v v0.14.0
npm ERR! node-pre-gyp ERR! not ok

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2023-08-09T08_56_17_771Z-debug-0.log
PWD=/path/to/tmp/fonts. Execute node ./generate.js
node:internal/modules/cjs/loader:1042
  throw err;
  ^

Error: Cannot find module 'fontnik'
Require stack:
- /path/to/tmp/fonts/generate.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1039:15)
    at Module._load (node:internal/modules/cjs/loader:885:27)
    at Module.require (node:internal/modules/cjs/loader:1105:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/path/to/tmp/fonts/generate.js:4:15)
    at Module._compile (node:internal/modules/cjs/loader:1218:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1272:10)
    at Module.load (node:internal/modules/cjs/loader:1081:32)
    at Module._load (node:internal/modules/cjs/loader:922:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/path/to/tmp/fonts/generate.js' ]
}
```